### PR TITLE
Allow cordial gp overcap if identical cast is active

### DIFF
--- a/AutoHook/Classes/AutoCasts/AutoCordial.cs
+++ b/AutoHook/Classes/AutoCasts/AutoCordial.cs
@@ -16,6 +16,8 @@ public class AutoCordial : BaseActionCast
 
     public bool InvertCordialPriority;
     
+    public bool AllowOvercapIC;
+    
     private readonly List<(uint, uint)> _cordialList = new()
     {
         (IDs.Item.HiCordial,        CordialHiRecovery),
@@ -55,9 +57,8 @@ public class AutoCordial : BaseActionCast
                 continue;
             
             Id = id;
-
-            var notOvercaped = PlayerResources.GetCurrentGp() + recovery < PlayerResources.GetMaxGp();
-            return notOvercaped;
+            
+            return CheckNotOvercaped(recovery);
         }
 
         return false;
@@ -70,10 +71,23 @@ public class AutoCordial : BaseActionCast
         else
             GpThreshold = newCost;
     }
+    
+    private bool CheckNotOvercaped(uint recovery)
+    {
+        if (AllowOvercapIC && PlayerResources.HasStatus(IDs.Status.IdenticalCast))
+            return true;
+        
+        return PlayerResources.GetCurrentGp() + recovery <= PlayerResources.GetMaxGp(); 
+    }
 
     protected override DrawOptionsDelegate DrawOptions => () =>
     {
         if (DrawUtil.Checkbox(UIStrings.AutoCastCordialPriority, ref InvertCordialPriority))
+        {
+            Service.Save();
+        }
+        
+        if (DrawUtil.Checkbox(UIStrings.Allow_Gp_Overcap, ref AllowOvercapIC))
         {
             Service.Save();
         }

--- a/AutoHook/HookManager.cs
+++ b/AutoHook/HookManager.cs
@@ -163,7 +163,12 @@ public class HookingManager : IDisposable
         var currentState = Service.EventFramework.FishingState;
 
         if (!Service.Configuration.PluginEnabled || currentState == FishingState.None)
+        {
+            if (_lastStep != FishingSteps.None)
+                OnFishingStop();
+            
             return;
+        }
 
         if (currentState != FishingState.Quit && _lastStep == FishingSteps.Quitting)
         {

--- a/AutoHook/Resources/Localization/UIStrings.Designer.cs
+++ b/AutoHook/Resources/Localization/UIStrings.Designer.cs
@@ -178,6 +178,15 @@ namespace AutoHook.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow GP overcap if Identical Cast is active.
+        /// </summary>
+        internal static string Allow_Gp_Overcap {
+            get {
+                return ResourceManager.GetString("Allow_Gp_Overcap", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Always Mooch.
         /// </summary>
         internal static string Always_Mooch {

--- a/AutoHook/Resources/Localization/UIStrings.resx
+++ b/AutoHook/Resources/Localization/UIStrings.resx
@@ -898,4 +898,7 @@ Check the Guide Tab for Guides.</value>
   <data name="RefreshWhenTimeIsLessThanOrEqual" xml:space="preserve">
     <value>Refresh when buff timer is less than or equal to</value>
   </data>
+  <data name="Allow_Gp_Overcap" xml:space="preserve">
+    <value>Allow GP overcap if Identical Cast is active</value>
+  </data>
 </root>


### PR DESCRIPTION
I thought it wouldn't hurt to add this to fix a problem that i saw on discord. This will allow the use of triple hook after casting Identical Cast.
