### PR TITLE
Fix AH not casting when enabled.

### DIFF
--- a/AutoHook/Fishing/FishingManager.cs
+++ b/AutoHook/Fishing/FishingManager.cs
@@ -193,8 +193,21 @@ public partial class FishingManager : IDisposable
     {
         var currentState = Service.BaitManager.FishingState;
 
-        if (!Service.Configuration.PluginEnabled || currentState == FishingState.NotFishing)
+        if (!Service.Configuration.PluginEnabled)
             return;
+
+        if (currentState == FishingState.NotFishing)
+        {
+            if (EzThrottler.Throttle("AutoStartFishing", 1000))
+            {
+                var autoCastCfg = GetAutoCastCfg();
+                if (autoCastCfg.EnableAll && autoCastCfg.CastLine.Enabled && PlayerRes.IsCastAvailable())
+                {
+                    StartFishing();
+                }
+            }
+            return;
+        }
 
         if (currentState != FishingState.Quit && _lastStep.HasFlag(FishingSteps.Quitting))
         {


### PR DESCRIPTION
Old behavior: AH when enabled, and player NotFishing, would do nothing.
New behavior: AH when enabled, sees player NotFishing, will use abilities selected and casts line(respects toggled abilities/cast line/Enable Actions toggles.)