### PR TITLE
Hide DTR completely when ShowCondition is not met

### DIFF
--- a/AutoHook/Utils/EzDtr2.cs
+++ b/AutoHook/Utils/EzDtr2.cs
@@ -42,13 +42,14 @@ public class EzDtr2 : IDisposable
 
     internal void OnUpdate(object _)
     {
-        if (Entry.Shown)
+        if (Entry != null)
         {
             if (ShowCondition != null && !ShowCondition())
             {
-                Entry.Text = string.Empty;
+                Entry.Shown = false;
                 return;
             }
+            Entry.Shown = true;
             Entry.Text = Text();
             if (OnClick != null)
                 Entry.OnClick = OnClick;
@@ -59,7 +60,7 @@ public class EzDtr2 : IDisposable
     {
         Svc.Framework.Update -= OnUpdate;
         Registered.Remove(this);
-        Entry.Remove();
+        Entry?.Remove();
     }
 
     public static void DisposeAll() => Registered.ToArray().Each(x => x.Dispose());


### PR DESCRIPTION
The current code uses an empty string to hide the entry, but this causes the entry to show with width 0 and causes extra spacing between adjacent elements, resulting in a long blank space in the bar. This changes it to use Entry.Shown, which hides it completely.

The user hide setting is read-only at Entry.UserHidden and is unrelated to Entry.Shown there is no need to check it as the current code does.