### PR TITLE
Add ability to delete folder and its contents

### DIFF
--- a/AutoHook/Fishing/FishingPresets.cs
+++ b/AutoHook/Fishing/FishingPresets.cs
@@ -86,6 +86,22 @@ public class FishingPresets : BasePreset
         Service.Save();
     }
 
+    public void RemoveFolderAndContents(Guid folderId)
+    {
+        var folder = Folders.Find(f => f.UniqueId == folderId);
+        if (folder == null)
+            return;
+
+        // Copy to avoid mutation during iteration (RemovePreset modifies folder.PresetIds)
+        foreach (var presetId in folder.PresetIds.ToList())
+        {
+            RemovePreset(presetId);
+        }
+
+        Folders.Remove(folder);
+        Service.Save();
+    }
+
     public bool IsPresetInAnyFolder(Guid presetId)
     {
         return Folders.Any(f => f.ContainsPreset(presetId));

--- a/AutoHook/Resources/Localization/UIStrings.Designer.cs
+++ b/AutoHook/Resources/Localization/UIStrings.Designer.cs
@@ -1909,6 +1909,24 @@ namespace AutoHook.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delete Folder and Contents.
+        /// </summary>
+        internal static string DeleteFolderAndContents {
+            get {
+                return ResourceManager.GetString("DeleteFolderAndContents", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hold SHIFT to delete the folder and all presets inside it..
+        /// </summary>
+        internal static string HoldShiftToDeleteFolderAndContents {
+            get {
+                return ResourceManager.GetString("HoldShiftToDeleteFolderAndContents", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hook.
         /// </summary>
         internal static string Hook {

--- a/AutoHook/Resources/Localization/UIStrings.resx
+++ b/AutoHook/Resources/Localization/UIStrings.resx
@@ -180,6 +180,12 @@
   <data name="HoldShiftToDelete" xml:space="preserve">
     <value>Hold SHIFT to delete.</value>
   </data>
+  <data name="DeleteFolderAndContents" xml:space="preserve">
+    <value>Delete Folder and Contents</value>
+  </data>
+  <data name="HoldShiftToDeleteFolderAndContents" xml:space="preserve">
+    <value>Hold SHIFT to delete the folder and all presets inside it.</value>
+  </data>
   <data name="Close" xml:space="preserve">
     <value>Close</value>
   </data>

--- a/AutoHook/Ui/TabFishingPresets.cs
+++ b/AutoHook/Ui/TabFishingPresets.cs
@@ -850,23 +850,20 @@ public class TabFishingPresets : BaseTab
             Notify.Success(UIStrings.FolderExported);
         }
 
-        bool isEmpty = folder.PresetIds.Count == 0;
-        using (var disabled = ImRaii.Disabled(!isEmpty || !ImGui.GetIO().KeyShift))
+        using (var disabled = ImRaii.Disabled(!ImGui.GetIO().KeyShift))
         {
-            if (ImGui.Selectable(UIStrings.Delete, false, ImGuiSelectableFlags.DontClosePopups))
+            if (ImGui.Selectable(UIStrings.DeleteFolderAndContents, false, ImGuiSelectableFlags.DontClosePopups))
             {
-                _basePreset.RemoveFolder(folder.UniqueId);
+                if (displayed != null && folder.ContainsPreset(displayed.UniqueId))
+                    displayed = null;
+
+                _basePreset.RemoveFolderAndContents(folder.UniqueId);
                 Service.Save();
             }
         }
 
         if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-        {
-            if (!isEmpty)
-                ImGui.SetTooltip(UIStrings.FolderMostBeEmpty);
-            else
-                ImGui.SetTooltip(UIStrings.HoldShiftToDelete);
-        }
+            ImGui.SetTooltip(UIStrings.HoldShiftToDeleteFolderAndContents);
 
         ImGui.EndPopup();
     }


### PR DESCRIPTION
Closes #103

Previously you had to empty a folder manually before you could delete it, which was tedious. Now there's a single **Delete Folder and Contents** option in the folder right-click menu that handles everything in one go.

Hold Shift to confirm (same as every other delete in the plugin, so no accidental nukes).

**What changed:**
- Replaced the old empty-folder-only Delete with `Delete Folder and Contents` — works on any folder
- If the folder being deleted contains the preset currently shown in the right panel, that panel clears automatically
- Added the backing `RemoveFolderAndContents` method to `FishingPresets` and the relevant localization strings