### PR TITLE
Handle WKS mission score field rename

### DIFF
--- a/AutoHook/WorldStateUpdater.cs
+++ b/AutoHook/WorldStateUpdater.cs
@@ -8,6 +8,7 @@ using FFXIVClientStructs.FFXIV.Client.Game.InstanceContent;
 using FFXIVClientStructs.FFXIV.Client.Game.WKS;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using Lumina.Excel.Sheets;
+using System.Reflection;
 
 namespace AutoHook;
 
@@ -25,6 +26,9 @@ public sealed class WorldStateUpdater : IDisposable {
     private readonly Hook<AgentCatch.Delegates.UpdateCatch>? _updateCatchHook;
     private readonly Hook<FishingEventHandler.Delegates.PlayAnimation>? _playAnimationHook;
     private static IReadOnlyList<Lumina.Excel.Sheets.Action> FshActions = [];
+    private static readonly FieldInfo? WksMissionScoreField =
+        typeof(WKSMissionModule.MissionState).GetField("ScoreUInt") ??
+        typeof(WKSMissionModule.MissionState).GetField("Score");
 
     private bool _needInventoryUpdate = true;
 
@@ -305,16 +309,26 @@ public sealed class WorldStateUpdater : IDisposable {
                 devGrade = wks->State.DevGrade;
                 currentFateControlRowId = wks->State.CurrentFateControlRowId;
                 currentFateId = wks->State.CurrentFateId;
-                currentMissionUnitRowId = wks->State.CurrentMission.MissionUnitRowId;
-                currentScore = wks->State.CurrentMission.ScoreUInt;
-                currentRank = wks->State.CurrentMission.Rank;
-                collectedTotal = wks->State.CurrentMission.CollectedTotal;
-                collectedIndividual = wks->State.CurrentMission.CollectedIndividual;
+                var mission = wks->State.CurrentMission;
+                currentMissionUnitRowId = mission.MissionUnitRowId;
+                currentScore = GetWksMissionScore(mission);
+                currentRank = mission.Rank;
+                collectedTotal = mission.CollectedTotal;
+                collectedIndividual = mission.CollectedIndividual;
             }
         }
         catch { }
 
         return new WKSInfo.OpState(devGrade, currentFateControlRowId, currentFateId, currentMissionUnitRowId, currentScore, currentRank, collectedTotal, collectedIndividual);
+    }
+
+    private static uint GetWksMissionScore(WKSMissionModule.MissionState mission) {
+        var score = WksMissionScoreField?.GetValue(mission);
+        return score switch {
+            uint value => value,
+            ushort value => value,
+            _ => 0,
+        };
     }
 
     private static unsafe WorldState.OpZone CollectZone()


### PR DESCRIPTION
## Summary
- Resolve WKS mission score through reflection so both `ScoreUInt` and `Score` field names are supported.
- Keep existing WKS state collection behavior for mission id, rank, and collection counters.
- Avoid a `MissingFieldException` from aborting `WorldStateUpdater.Update()` every framework tick when the active FFXIVClientStructs build exposes the score field as `Score`.

## Root cause
On a CN Dalamud environment using `FFXIVClientStructs.dll` from `XIVLauncherCN\addon\Hooks\15.0.2.1`, `WKSMissionModule.MissionState` exposes these fields:

```text
MissionUnitRowId
Score
Rank
CollectedTotal
CollectedIndividual
```

The current direct reference to `CurrentMission.ScoreUInt` throws continuously:

```text
System.MissingFieldException: Field not found: 'MissionState.ScoreUInt'.
   at AutoHook.WorldStateUpdater.CollectWKSInfo()
   at AutoHook.WorldStateUpdater.Update()
   at AutoHook.Fishing.FishingManager.OnFrameworkUpdate(...)
```

Because this happens before later fishing update handling, the plugin can still start/cast in some paths but fails to reliably process bite/hook behavior.

## Validation
- Confirmed the reported `ScoreUInt` compile/runtime incompatibility against the local CN Dalamud `FFXIVClientStructs.dll`.
- Ran `dotnet build AutoHook.sln` with `DALAMUD_HOME` pointed at `XIVLauncherCN\addon\Hooks\15.0.2.1`; the previous `ScoreUInt` error is gone.
- Build is still blocked by an unrelated existing error on current `main`: `AutoHook/Ui/SubTabAutoCast.cs(9,71): error CS0103: The name 'with' does not exist in the current context`.
